### PR TITLE
Avoid ruby 2.4+ methods

### DIFF
--- a/lib/erb.rb
+++ b/lib/erb.rb
@@ -667,7 +667,7 @@ class ERB
       when 0, nil
         return [false, nil]
       when String
-        unless mode.match?(/\A(%|-|>|<>){1,2}\z/)
+        unless mode.match(/\A(%|-|>|<>){1,2}\z/)
           warn_invalid_trim_mode(mode, uplevel: 5)
         end
 
@@ -1020,7 +1020,7 @@ class ERB
     #
     def url_encode(s)
       s.to_s.b.gsub(/[^a-zA-Z0-9_\-.~]/n) { |m|
-        sprintf("%%%02X", m.unpack1("C"))
+        sprintf("%%%02X", m.unpack("C").first)
       }
     end
     alias u url_encode

--- a/test/lib/core_assertions.rb
+++ b/test/lib/core_assertions.rb
@@ -304,7 +304,7 @@ eom
         assert(!abort, FailDesc[status, nil, stderr])
         self._assertions += res[/^assertions=(\d+)/, 1].to_i
         begin
-          res = Marshal.load(res.unpack1("m"))
+          res = Marshal.load(res.unpack("m").first)
         rescue => marshal_error
           ignore_stderr = nil
           res = nil


### PR DESCRIPTION
https://github.com/ruby/erb/blob/9cef1029e0ed25c6059a4f6662e36a4171177af1/.github/workflows/test.yml#L9-L15
https://github.com/ruby/erb/blob/9cef1029e0ed25c6059a4f6662e36a4171177af1/erb.gemspec#L17

Currently supporting as 2.3+, but testing in 2.5+
This does not run from some reasons.

* Using String#match?
* Using String#unpack1

Both are not in ruby 2.3

So I think need some changes.

* Clarify to support 2.4+ or 2.5+ 
* Avoid 2.4+ feature

This PR aims `Avoid 2.4+ feature`, but some test still fail on `rubylang/ruby:2.3.8-bionic` even after applied this patch.

```
Error: test_invalid_trim_mode(TestERBCore): NoMethodError: undefined method `diff' for #<TestERBCore:0x000055c07dff2150>                                                                                         [35/1068]
/usr/src/test/lib/core_assertions.rb:509:in `block in assert_warning'
/usr/src/test/lib/core_assertions.rb:21:in `block in message'
/usr/src/test/lib/core_assertions.rb:510:in `assert_warning'
/usr/src/test/erb/test_erb.rb:239:in `test_invalid_trim_mode'
     236:   end
     237:
     238:   def test_invalid_trim_mode
  => 239:     assert_warning(/#{__FILE__}:#{__LINE__ + 1}/) do
     240:       @erb.new("", trim_mode: 'abc-def')
     241:     end                                                                                                                                                                                                              242:
```

```
Failure:                                                                                                                                                                                                         [20/1068]
  pid 18 exit 0
  | warning: -S option of erb command is deprecated. Please do not use this.
  | Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.
  | {:uplevel=>1}
  .

  1. [2/2] Assertion for "stderr"
     | Expected /\n.+\/libexec\/erb:\d+: warning: Passing safe_level with the 2nd argument of ERB\.new is deprecated\. Do not use it, and specify other arguments as keyword arguments\.\n/
     | to match
     |   "\n"+
     |   "Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.\n"+
     |   "{:uplevel=>1}\n"
     | after 1 patterns with 72 characters.
     | <false> is not true.
  <false> is not true.
test_deprecated_option(TestErbCommand)
/usr/src/test/lib/core_assertions.rb:617:in `assert_all_assertions'
/usr/src/test/lib/core_assertions.rb:71:in `assert_in_out_err'
/usr/src/test/erb/test_erb_command.rb:25:in `test_deprecated_option'
     22:       "warning: -S option of erb command is deprecated. Please do not use this.",
     23:       /\n.+\/libexec\/erb:\d+: warning: Passing safe_level with the 2nd argument of ERB\.new is deprecated\. Do not use it, and specify other arguments as keyword arguments\.\n/,
     24:     ]
```

I'm not sure the root cause.
But this change might be work on Ruby 2.3, Iguess.

I'll create another PR for `Clarify to support 2.4+ or 2.5+ `.