### PR TITLE
Clarify supported ruby versions in gemspec

### DIFF
--- a/erb.gemspec
+++ b/erb.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.summary       = %q{An easy to use but powerful templating system for Ruby.}
   spec.description   = %q{An easy to use but powerful templating system for Ruby.}
   spec.homepage      = 'https://github.com/ruby/erb'
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.3.0')
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.5.0')
   spec.licenses      = ['Ruby', 'BSD-2-Clause']
 
   spec.metadata['homepage_uri'] = spec.homepage


### PR DESCRIPTION
Another way of https://github.com/ruby/erb/pull/2

This PR just drops support ended rubies.

* `rubylang/ruby:2.4.9-bionic'` fails tests same as https://github.com/ruby/erb/pull/2
* 2.4 support is ended

So this change is enough?
