### PR TITLE
fix regexp

### DIFF
--- a/lib/erb.rb
+++ b/lib/erb.rb
@@ -724,7 +724,7 @@ class ERB
       frozen = nil
       s.scan(re) do
         comment = $+
-        comment = $1 if comment[/-\*-\s*(.*?)\s*-*-$/]
+        comment = $1 if comment[/-\*-\s*([^\s].*?)\s*-*-$/]
         case comment
         when %r"coding\s*[=:]\s*([[:alnum:]\-_]+)"
           enc = Encoding.find($1.sub(/-(?:mac|dos|unix)/i, ''))


### PR DESCRIPTION
I used [Regexploit](https://github.com/doyensec/regexploit) to find a regular expression that could be ReDoS for erb.
It's not a security issue, and I think it's extremely rare that it could affect performance.

### sample 

```ruby
require 'erb'

template = ERB.new <<EOF
<%#-*-#{' '* 3456}%>
  __ENCODING__ is <%= __ENCODING__ %>.
EOF
puts template.result
```

```
❯ time ruby redos.rb

  __ENCODING__ is UTF-8.
ruby redos.rb  41.21s user 0.18s system 99% cpu 41.541 total
```

### Results of Regexploit

```
-\*-\s*(.*?)\s*-*-$
Pattern: -\*-\s*(.*?)\s*-*-$
---
Redos(starriness=3, prefix_sequence=SEQ{ [2d:-] [2a:*] [2d:-] }, redos_sequence=SEQ{ [SPACE]{0+} .{0+} [SPACE]{0+} [2d:-]{0+} [2d:-] }, repeated_character=[SPACE], killer=None)
Worst-case complexity: 3 ⭐⭐⭐ (cubic)
Repeated character: [SPACE]
Example: '-*-' + ' ' * 3456

/-\*-\s*([^\s].*?)\s*-*-$/
No ReDoS found.
```