### PR TITLE
url_encode: use CGI.escapeURIComponent

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - id: versions
         run: |
-          versions=$(curl -s 'https://cache.ruby-lang.org/pub/misc/ci_versions/cruby.json' | jq -c '. + ["2.5"]')
+          versions=$(curl -s 'https://cache.ruby-lang.org/pub/misc/ci_versions/cruby.json')
           echo "::set-output name=value::${versions}"
   test:
     needs: ruby-versions

--- a/erb.gemspec
+++ b/erb.gemspec
@@ -27,5 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables   = ['erb']
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'cgi'
+  spec.required_ruby_version = ">= 2.7.0"
+
+  spec.add_dependency 'cgi', '>= 0.3.3'
 end

--- a/lib/erb.rb
+++ b/lib/erb.rb
@@ -1019,9 +1019,7 @@ class ERB
     #   Programming%20Ruby%3A%20%20The%20Pragmatic%20Programmer%27s%20Guide
     #
     def url_encode(s)
-      s.to_s.b.gsub(/[^a-zA-Z0-9_\-.~]/n) { |m|
-        sprintf("%%%02X", m.unpack1("C"))
-      }
+      CGI.escapeURIComponent(s.to_s)
     end
     alias u url_encode
     module_function :u


### PR DESCRIPTION
Ref: https://github.com/ruby/cgi/pull/26

This native implementation is much faster and available in `cgi 0.3.3`.
