### PR TITLE
 Optimize ERB::Util.html_escape more than CGI.escapeHTML for template engines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 /spec/reports/
 /tmp/
 Gemfile.lock
+*.so
+*.gem

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,8 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'rake'
-gem 'test-unit'
+group :development do
+  gem 'rake'
+  gem 'rake-compiler'
+  gem 'test-unit'
+end

--- a/Rakefile
+++ b/Rakefile
@@ -7,6 +7,12 @@ Rake::TestTask.new(:test) do |t|
   t.test_files = FileList['test/**/test_*.rb']
 end
 
+if RUBY_ENGINE != 'jruby'
+  require 'rake/extensiontask'
+  Rake::ExtensionTask.new('erb')
+  task test: :compile
+end
+
 task :sync_tool do
   require 'fileutils'
   FileUtils.cp '../ruby/tool/lib/core_assertions.rb', './test/lib'

--- a/erb.gemspec
+++ b/erb.gemspec
@@ -27,8 +27,11 @@ Gem::Specification.new do |spec|
   spec.executables   = ['erb']
   spec.require_paths = ['lib']
 
-  if RUBY_ENGINE != 'jruby'
+  if RUBY_ENGINE == 'jruby'
+    spec.platform = 'java'
+  else
     spec.required_ruby_version = '>= 2.7.0'
+    spec.extensions = ['ext/erb/extconf.rb']
   end
 
   spec.add_dependency 'cgi', '>= 0.3.3'

--- a/ext/erb/erb.c
+++ b/ext/erb/erb.c
@@ -1,0 +1,96 @@
+#include "ruby.h"
+#include "ruby/encoding.h"
+
+static VALUE rb_cERB, rb_mEscape;
+
+#define HTML_ESCAPE_MAX_LEN 6
+
+static const struct {
+    uint8_t len;
+    char str[HTML_ESCAPE_MAX_LEN+1];
+} html_escape_table[UCHAR_MAX+1] = {
+#define HTML_ESCAPE(c, str) [c] = {rb_strlen_lit(str), str}
+    HTML_ESCAPE('\'', "&#39;"),
+    HTML_ESCAPE('&', "&amp;"),
+    HTML_ESCAPE('"', "&quot;"),
+    HTML_ESCAPE('<', "&lt;"),
+    HTML_ESCAPE('>', "&gt;"),
+#undef HTML_ESCAPE
+};
+
+static inline void
+preserve_original_state(VALUE orig, VALUE dest)
+{
+    rb_enc_associate(dest, rb_enc_get(orig));
+}
+
+static inline long
+escaped_length(VALUE str)
+{
+    const long len = RSTRING_LEN(str);
+    if (len >= LONG_MAX / HTML_ESCAPE_MAX_LEN) {
+        ruby_malloc_size_overflow(len, HTML_ESCAPE_MAX_LEN);
+    }
+    return len * HTML_ESCAPE_MAX_LEN;
+}
+
+static VALUE
+optimized_escape_html(VALUE str)
+{
+    VALUE vbuf;
+    char *buf = ALLOCV_N(char, vbuf, escaped_length(str));
+    const char *cstr = RSTRING_PTR(str);
+    const char *end = cstr + RSTRING_LEN(str);
+
+    char *dest = buf;
+    while (cstr < end) {
+        const unsigned char c = *cstr++;
+        uint8_t len = html_escape_table[c].len;
+        if (len) {
+            memcpy(dest, html_escape_table[c].str, len);
+            dest += len;
+        }
+        else {
+            *dest++ = c;
+        }
+    }
+
+    VALUE escaped;
+    if (RSTRING_LEN(str) < (dest - buf)) {
+        escaped = rb_str_new(buf, dest - buf);
+        preserve_original_state(str, escaped);
+    }
+    else {
+        escaped = rb_str_dup(str);
+    }
+    ALLOCV_END(vbuf);
+    return escaped;
+}
+
+static VALUE
+cgiesc_escape_html(VALUE self, VALUE str)
+{
+    StringValue(str);
+
+    if (rb_enc_str_asciicompat_p(str)) {
+        return optimized_escape_html(str);
+    }
+    else {
+        return rb_call_super(1, &str);
+    }
+}
+
+static VALUE
+erb_escape_html(VALUE self, VALUE str)
+{
+    str = rb_funcall(str, rb_intern("to_s"), 0);
+    return cgiesc_escape_html(self, str);
+}
+
+void
+Init_erb(void)
+{
+    rb_cERB = rb_define_class("ERB", rb_cObject);
+    rb_mEscape = rb_define_module_under(rb_cERB, "Escape");
+    rb_define_method(rb_mEscape, "html_escape", erb_escape_html, 1);
+}

--- a/ext/erb/erb.c
+++ b/ext/erb/erb.c
@@ -68,9 +68,9 @@ optimized_escape_html(VALUE str)
 }
 
 static VALUE
-cgiesc_escape_html(VALUE self, VALUE str)
+erb_escape_html(VALUE self, VALUE str)
 {
-    StringValue(str);
+    str = rb_convert_type(str, T_STRING, "String", "to_s");
 
     if (rb_enc_str_asciicompat_p(str)) {
         return optimized_escape_html(str);
@@ -78,13 +78,6 @@ cgiesc_escape_html(VALUE self, VALUE str)
     else {
         return rb_call_super(1, &str);
     }
-}
-
-static VALUE
-erb_escape_html(VALUE self, VALUE str)
-{
-    str = rb_funcall(str, rb_intern("to_s"), 0);
-    return cgiesc_escape_html(self, str);
 }
 
 void

--- a/ext/erb/erb.c
+++ b/ext/erb/erb.c
@@ -55,18 +55,18 @@ optimized_escape_html(VALUE str)
         }
     }
 
-    VALUE escaped;
+    VALUE escaped = str;
     if (RSTRING_LEN(str) < (dest - buf)) {
         escaped = rb_str_new(buf, dest - buf);
         preserve_original_state(str, escaped);
-    }
-    else {
-        escaped = rb_str_dup(str);
     }
     ALLOCV_END(vbuf);
     return escaped;
 }
 
+// ERB::Util.html_escape is different from CGI.escapeHTML in the following two parts:
+//   * ERB::Util.html_escape converts an argument with #to_s first (only if it's not T_STRING)
+//   * ERB::Util.html_escape does not allocate a new string when nothing needs to be escaped
 static VALUE
 erb_escape_html(VALUE self, VALUE str)
 {

--- a/ext/erb/extconf.rb
+++ b/ext/erb/extconf.rb
@@ -1,0 +1,2 @@
+require 'mkmf'
+create_makefile 'erb'

--- a/lib/erb.rb
+++ b/lib/erb.rb
@@ -986,7 +986,6 @@ end
 class ERB
   # A utility module for conversion routines, often handy in HTML generation.
   module Util
-    public
     #
     # A utility method for escaping HTML tag characters in _s_.
     #
@@ -1002,6 +1001,17 @@ class ERB
     def html_escape(s)
       CGI.escapeHTML(s.to_s)
     end
+  end
+
+  begin
+    require 'erb.so'
+  rescue LoadError
+  else
+    private_constant :Escape
+    Util.prepend(Escape)
+  end
+
+  module Util
     alias h html_escape
     module_function :h
     module_function :html_escape

--- a/test/erb/test_erb.rb
+++ b/test/erb/test_erb.rb
@@ -73,10 +73,23 @@ class TestERB < Test::Unit::TestCase
     assert_equal("", ERB::Util.html_escape(""))
     assert_equal("abc", ERB::Util.html_escape("abc"))
     assert_equal("&lt;&lt;", ERB::Util.html_escape("<\<"))
+    assert_equal("&#39;&amp;&quot;&gt;&lt;", ERB::Util.html_escape("'&\"><"))
 
     assert_equal("", ERB::Util.html_escape(nil))
     assert_equal("123", ERB::Util.html_escape(123))
   end
+
+  def test_html_escape_to_s
+    object = Object.new
+    def object.to_s
+      "object"
+    end
+    assert_equal("object", ERB::Util.html_escape(object))
+  end
+
+  def test_html_escape_extension
+    assert_nil(ERB::Util.method(:html_escape).source_location)
+  end if RUBY_ENGINE == 'ruby'
 
   def test_concurrent_default_binding
     # This test randomly fails with JRuby -- NameError: undefined local variable or method `template2'


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/19102

## Benchmark
```rb
require 'benchmark/ips'
require 'erb'

class << ERB::Util
  def html_escape_old(s)
    CGI.escapeHTML(s.to_s)
  end
end

Benchmark.ips do |x|
  s = 'hello world'
  x.report('before') { ERB::Util.html_escape_old(s) }
  x.report('after')  { ERB::Util.html_escape(s) }
  x.compare!
end
```

```
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [x86_64-linux]
Warming up --------------------------------------
              before     1.066M i/100ms
               after     1.879M i/100ms
Calculating -------------------------------------
              before     10.615M (± 0.3%) i/s -     53.320M in   5.023083s
               after     18.742M (± 0.4%) i/s -     93.929M in   5.011847s

Comparison:
               after: 18741747.6 i/s
              before: 10615137.1 i/s - 1.77x  (± 0.00) slower
```