### PR TITLE
Avoid using prepend + super for fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@
 /tmp/
 Gemfile.lock
 *.so
+*.bundle
 *.gem

--- a/ext/erb/erb.c
+++ b/ext/erb/erb.c
@@ -1,7 +1,8 @@
 #include "ruby.h"
 #include "ruby/encoding.h"
 
-static VALUE rb_cERB, rb_mEscape;
+static VALUE rb_cERB, rb_mUtil, rb_cCGI;
+static ID id_escapeHTML;
 
 #define HTML_ESCAPE_MAX_LEN 6
 
@@ -76,7 +77,7 @@ erb_escape_html(VALUE self, VALUE str)
         return optimized_escape_html(str);
     }
     else {
-        return rb_call_super(1, &str);
+        return rb_funcall(rb_cCGI, id_escapeHTML, 1, str);
     }
 }
 
@@ -84,6 +85,9 @@ void
 Init_erb(void)
 {
     rb_cERB = rb_define_class("ERB", rb_cObject);
-    rb_mEscape = rb_define_module_under(rb_cERB, "Escape");
-    rb_define_method(rb_mEscape, "html_escape", erb_escape_html, 1);
+    rb_mUtil = rb_define_module_under(rb_cERB, "Util");
+    rb_define_method(rb_mUtil, "html_escape", erb_escape_html, 1);
+
+    rb_cCGI = rb_define_class("CGI", rb_cObject);
+    id_escapeHTML = rb_intern("escapeHTML");
 }

--- a/lib/erb.rb
+++ b/lib/erb.rb
@@ -998,20 +998,14 @@ class ERB
     #
     #   is a &gt; 0 &amp; a &lt; 10?
     #
-    def html_escape(s)
-      CGI.escapeHTML(s.to_s)
+    begin
+      # ERB::Util.html_escape
+      require 'erb.so'
+    rescue LoadError
+      def html_escape(s)
+        CGI.escapeHTML(s.to_s)
+      end
     end
-  end
-
-  begin
-    require 'erb.so'
-  rescue LoadError
-  else
-    private_constant :Escape
-    Util.prepend(Escape)
-  end
-
-  module Util
     alias h html_escape
     module_function :h
     module_function :html_escape


### PR DESCRIPTION
`prepend` is prioritized more than ActiveSupport's monkey-patch, but the monkey-patch needs to work.