### PR TITLE
Avoid being slower than the previous version for most cases

### DIFF
--- a/ext/erb/erb.c
+++ b/ext/erb/erb.c
@@ -76,7 +76,9 @@ optimized_escape_html(VALUE str)
 static VALUE
 erb_escape_html(VALUE self, VALUE str)
 {
-    str = rb_convert_type(str, T_STRING, "String", "to_s");
+    if (!RB_TYPE_P(str, T_STRING)) {
+        str = rb_convert_type(str, T_STRING, "String", "to_s");
+    }
 
     if (rb_enc_str_asciicompat_p(str)) {
         return optimized_escape_html(str);


### PR DESCRIPTION
## Benchmark
Test benchmarks in [benchmark/cgi_escape_html.yml](https://github.com/ruby/ruby/blob/419d2fc14d2bedc6d5a7080ee80df8330884ea6c/benchmark/cgi_escape_html.yml) in ruby/ruby, modified for comparing it with other implementations:

<details>
<summary>Base benchmark script</summary>

```rb
# frozen_string_literal: true
require 'benchmark/ips'
require 'cgi'
require 'erb'
require 'hescape'

class << ERB::Util
  def html_escape_old(s)
    CGI.escapeHTML(s.to_s)
  end
end

Benchmark.ips do |x|
  s = ""
<summary>
  x.report('CGI.escapeHTML')        { CGI.escapeHTML(s) }
  x.report('ERB::Util.html_escape') { ERB::Util.html_escape(s) }
  x.report('Hescape.escape_html')   { Hescape.escape_html(s) }
  x.compare!
end
```

</details>

Please see the "Other benchmarks" in https://github.com/ruby/erb/pull/29 for the previous results.

### No escape ("")
```
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [x86_64-linux]
Warming up --------------------------------------
      CGI.escapeHTML     1.512M i/100ms
ERB::Util.html_escape
                         2.017M i/100ms
 Hescape.escape_html     2.172M i/100ms
Calculating -------------------------------------
      CGI.escapeHTML     15.069M (± 0.5%) i/s -     75.617M in   5.018166s
ERB::Util.html_escape
                         20.589M (± 0.4%) i/s -    104.860M in   5.093209s
 Hescape.escape_html     21.856M (± 0.5%) i/s -    110.793M in   5.069431s

Comparison:
 Hescape.escape_html: 21855785.2 i/s
ERB::Util.html_escape: 20588507.3 i/s - 1.06x  (± 0.00) slower
      CGI.escapeHTML: 15068987.1 i/s - 1.45x  (± 0.00) slower
```

### No escape ("abcde")
```
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [x86_64-linux]
Warming up --------------------------------------
      CGI.escapeHTML     1.467M i/100ms
ERB::Util.html_escape
                         2.012M i/100ms
 Hescape.escape_html     2.194M i/100ms
Calculating -------------------------------------
      CGI.escapeHTML     14.956M (± 0.2%) i/s -     74.803M in   5.001458s
ERB::Util.html_escape
                         19.909M (± 0.4%) i/s -    100.618M in   5.053980s
 Hescape.escape_html     21.823M (± 0.6%) i/s -    109.710M in   5.027353s

Comparison:
 Hescape.escape_html: 21823359.3 i/s
ERB::Util.html_escape: 19908988.8 i/s - 1.10x  (± 0.00) slower
      CGI.escapeHTML: 14956247.0 i/s - 1.46x  (± 0.00) slower
```

### No escape ("abcde" * 300)
```
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [x86_64-linux]
Warming up --------------------------------------
      CGI.escapeHTML   170.882k i/100ms
ERB::Util.html_escape
                       859.175k i/100ms
 Hescape.escape_html   665.473k i/100ms
Calculating -------------------------------------
      CGI.escapeHTML      1.711M (± 0.1%) i/s -      8.715M in   5.094637s
ERB::Util.html_escape
                          8.592M (± 1.0%) i/s -     43.818M in   5.100138s
 Hescape.escape_html      6.666M (± 0.3%) i/s -     33.939M in   5.091419s

Comparison:
ERB::Util.html_escape:  8592336.5 i/s
 Hescape.escape_html:  6665993.9 i/s - 1.29x  (± 0.00) slower
      CGI.escapeHTML:  1710620.8 i/s - 5.02x  (± 0.00) slower
```

### Escaped ("abcd<")
```
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [x86_64-linux]
Warming up --------------------------------------
      CGI.escapeHTML     1.179M i/100ms
ERB::Util.html_escape
                         1.172M i/100ms
 Hescape.escape_html     1.084M i/100ms
Calculating -------------------------------------
      CGI.escapeHTML     12.039M (± 0.3%) i/s -     61.287M in   5.090689s
ERB::Util.html_escape
                         11.868M (± 0.2%) i/s -     59.760M in   5.035275s
 Hescape.escape_html     11.060M (± 0.2%) i/s -     56.382M in   5.097839s

Comparison:
      CGI.escapeHTML: 12039158.0 i/s
ERB::Util.html_escape: 11868277.6 i/s - 1.01x  (± 0.00) slower
 Hescape.escape_html: 11060112.3 i/s - 1.09x  (± 0.00) slower
```

### Escaped ("'&"<>")
```
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [x86_64-linux]
Warming up --------------------------------------
      CGI.escapeHTML   830.390k i/100ms
ERB::Util.html_escape
                       823.000k i/100ms
 Hescape.escape_html   610.832k i/100ms
Calculating -------------------------------------
      CGI.escapeHTML      8.300M (± 0.5%) i/s -     41.520M in   5.002448s
ERB::Util.html_escape
                          8.351M (± 0.1%) i/s -     41.973M in   5.026322s
 Hescape.escape_html      6.183M (± 0.2%) i/s -     31.152M in   5.038525s

Comparison:
ERB::Util.html_escape:  8350655.8 i/s
      CGI.escapeHTML:  8300041.9 i/s - same-ish: difference falls within error
 Hescape.escape_html:  6182862.3 i/s - 1.35x  (± 0.00) slower
```

### Escaped ("'&"<>" * 10)
```
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [x86_64-linux]
Warming up --------------------------------------
      CGI.escapeHTML   617.472k i/100ms
ERB::Util.html_escape
                       570.975k i/100ms
 Hescape.escape_html   173.898k i/100ms
Calculating -------------------------------------
      CGI.escapeHTML      6.200M (± 0.1%) i/s -     31.491M in   5.079015s
ERB::Util.html_escape
                          5.933M (± 1.0%) i/s -     29.691M in   5.004909s
 Hescape.escape_html      1.762M (± 0.2%) i/s -      8.869M in   5.034497s

Comparison:
      CGI.escapeHTML:  6200240.5 i/s
ERB::Util.html_escape:  5932900.8 i/s - 1.05x  (± 0.00) slower
 Hescape.escape_html:  1761612.4 i/s - 3.52x  (± 0.00) slower
```

### Escaped (example.com)
```
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [x86_64-linux]
Warming up --------------------------------------
      CGI.escapeHTML   307.513k i/100ms
ERB::Util.html_escape
                       296.819k i/100ms
 Hescape.escape_html   268.722k i/100ms
Calculating -------------------------------------
      CGI.escapeHTML      2.938M (± 0.3%) i/s -     14.761M in   5.023658s
ERB::Util.html_escape
                          2.962M (± 0.2%) i/s -     14.841M in   5.010141s
 Hescape.escape_html      2.740M (± 0.2%) i/s -     13.705M in   5.002157s

Comparison:
ERB::Util.html_escape:  2962196.1 i/s
      CGI.escapeHTML:  2938250.2 i/s - 1.01x  (± 0.00) slower
 Hescape.escape_html:  2739791.9 i/s - 1.08x  (± 0.00) slower
```