### PR TITLE
support using `<%-=` to trim the spaces prior to ruby expression

### DIFF
--- a/lib/erb.rb
+++ b/lib/erb.rb
@@ -280,7 +280,7 @@ class ERB
   #     %  enables Ruby code processing for lines beginning with %
   #     <> omit newline for lines starting with <% and ending in %>
   #     >  omit newline for lines ending in %>
-  #     -  omit blank lines ending in -%>
+  #     -  omit blank lines ending in -%>, beginning in <%- or <%-=(only when the output is nil or '')
   #
   # _eoutvar_ can be used to set the name of the variable ERB will build up
   # its output in.  This is useful when you need to run multiple ERB

--- a/lib/erb/version.rb
+++ b/lib/erb/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 class ERB
-  VERSION = '4.0.0'
+  VERSION = '4.1.0'
   private_constant :VERSION
 end

--- a/test/erb/test_erb.rb
+++ b/test/erb/test_erb.rb
@@ -251,6 +251,17 @@ EOS
     assert_equal("line\r\n" * 3, erb.result)
   end
 
+  def test_explicit_trim_line_with_expression
+    erb = @erb.new("line\r\n    <%-= 'value' %>\nline", trim_mode: '-')
+    assert_equal("line\r\n    value\nline", erb.result)
+
+    erb = @erb.new("line\r\n    <%-= 'value' if false %>\nline", trim_mode: '-')
+    assert_equal("line\r\n\nline", erb.result)
+
+    erb = @erb.new("line\r\n    <%-= 'value' if false -%>\nline", trim_mode: '-')
+    assert_equal("line\r\nline", erb.result)
+  end
+
   def test_invalid_trim_mode
     pend if RUBY_ENGINE == 'truffleruby'
 


### PR DESCRIPTION
fix https://github.com/ruby/erb/issues/24

1. `<%-=` performs different outputs based on the result of ruby expression: it only trims the spaces when the result of ruby expression is `nil` or `''`. So that its implementation is a bit different with the other stags.
2. `<%=-` is not compatible with the expressions start with negative number like `<%=-1%>`, so I choose `<%-=`.