### PR TITLE
Rename erb.so to erb/escape.so

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,7 @@ end
 
 if RUBY_ENGINE != 'jruby'
   require 'rake/extensiontask'
-  Rake::ExtensionTask.new('erb')
+  Rake::ExtensionTask.new('erb/escape')
   task test: :compile
 end
 

--- a/erb.gemspec
+++ b/erb.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
     spec.platform = 'java'
   else
     spec.required_ruby_version = '>= 2.7.0'
-    spec.extensions = ['ext/erb/extconf.rb']
+    spec.extensions = ['ext/erb/escape/extconf.rb']
   end
 
   spec.add_dependency 'cgi', '>= 0.3.3'

--- a/ext/erb/escape/escape.c
+++ b/ext/erb/escape/escape.c
@@ -84,7 +84,7 @@ erb_escape_html(VALUE self, VALUE str)
 }
 
 void
-Init_erb(void)
+Init_escape(void)
 {
     rb_cERB = rb_define_class("ERB", rb_cObject);
     rb_mUtil = rb_define_module_under(rb_cERB, "Util");

--- a/ext/erb/escape/extconf.rb
+++ b/ext/erb/escape/extconf.rb
@@ -1,0 +1,2 @@
+require 'mkmf'
+create_makefile 'erb/escape'

--- a/ext/erb/extconf.rb
+++ b/ext/erb/extconf.rb
@@ -1,2 +1,0 @@
-require 'mkmf'
-create_makefile 'erb'

--- a/lib/erb.rb
+++ b/lib/erb.rb
@@ -1000,7 +1000,7 @@ class ERB
     #
     begin
       # ERB::Util.html_escape
-      require 'erb.so'
+      require 'erb/escape'
     rescue LoadError
       def html_escape(s)
         CGI.escapeHTML(s.to_s)


### PR DESCRIPTION
Partly address https://github.com/ruby/erb/issues/32. I'll work on adding `ERB::Escape` in a different PR.