### PR TITLE
Allow requiring erb/escape.so alone

### DIFF
--- a/lib/erb/util.rb
+++ b/lib/erb/util.rb
@@ -1,3 +1,9 @@
+begin
+  # ERB::Util.html_escape
+  require 'erb/escape'
+rescue LoadError # JRuby can't load .so
+end
+
 #--
 # ERB::Util
 #
@@ -15,10 +21,7 @@ module ERB::Util
   #
   #   is a &gt; 0 &amp; a &lt; 10?
   #
-  begin
-    # ERB::Util.html_escape
-    require 'erb/escape'
-  rescue LoadError
+  unless method_defined?(:html_escape) # for JRuby
     def html_escape(s)
       CGI.escapeHTML(s.to_s)
     end


### PR DESCRIPTION
Prior to this commit, requiring erb/escape first and then requiring erb did not work as expected.

This PR partly helps https://github.com/ruby/erb/issues/32.