### PR TITLE
Correctly compute buffer line offset.

### DIFF
--- a/lib/erb.rb
+++ b/lib/erb.rb
@@ -426,7 +426,7 @@ class ERB
     unless @_init.equal?(self.class.singleton_class)
       raise ArgumentError, "not initialized"
     end
-    eval(@src, b, (@filename || '(erb)'), @lineno)
+    eval(@src.script, b, (@filename || '(erb)'), @lineno - @src.line_offset)
   end
 
   # Render a template on a new toplevel binding with local variables specified

--- a/lib/erb.rb
+++ b/lib/erb.rb
@@ -350,7 +350,7 @@ class ERB
     set_eoutvar(compiler, eoutvar)
     @src, @encoding, @frozen_string = *compiler.compile(str)
     @filename = nil
-    @lineno = 0
+    @lineno = 1
     @_init = self.class.singleton_class
   end
   NOT_GIVEN = Object.new
@@ -463,7 +463,7 @@ class ERB
   #   erb.def_method(MyClass, 'render(arg1, arg2)', filename)
   #   print MyClass.new.render('foo', 123)
   def def_method(mod, methodname, fname='(ERB)')
-    src = self.src.sub(/^(?!#|$)/) {"def #{methodname}\n"} << "\nend\n"
+    src = self.src.script.sub(/^(?!#|$)/) {"def #{methodname}\n"} << "\nend\n"
     mod.module_eval do
       eval(src, binding, fname, -1)
     end

--- a/lib/erb/compiler.rb
+++ b/lib/erb/compiler.rb
@@ -282,7 +282,7 @@ class ERB::Compiler # :nodoc:
 
       # Add the script options on a single line:
       if script_options.any?
-        @script << "# #{script_options.join(' ')}\n"
+        @script << "\##{script_options.join(' ')}\n"
         @line_offset += 1
       end
 
@@ -325,8 +325,8 @@ class ERB::Compiler # :nodoc:
   end
 
   def add_put_cmd(out, content, offset = 0)
-    line_count = content.count("\n")
-    out.push("#{@put_cmd} #{content.dump}.freeze#{"\n" * line_count}")
+    content = content.gsub("'", "\\\\'")
+    out.push("#{@put_cmd} '#{content}'")
   end
 
   def add_insert_cmd(out, content)

--- a/test/erb/test_erb.rb
+++ b/test/erb/test_erb.rb
@@ -54,7 +54,7 @@ class TestERB < Test::Unit::TestCase
     e = assert_raise(MyError) {
       erb.result
     }
-    assert_match(/\Atest filename:101\b/, e.backtrace[0])
+    assert_match(/\Atest filename:100\b/, e.backtrace[0])
   end
 
   def test_with_location
@@ -63,7 +63,7 @@ class TestERB < Test::Unit::TestCase
     e = assert_raise(MyError) {
       erb.result
     }
-    assert_match(/\Atest filename:201\b/, e.backtrace[0])
+    assert_match(/\Atest filename:200\b/, e.backtrace[0])
   end
 
   def test_html_escape
@@ -627,7 +627,7 @@ EOS
   def test_frozen_string_literal
     bug12031 = '[ruby-core:73561] [Bug #12031]'
     e = @erb.new("<%#encoding: us-ascii%>a")
-    e.src.sub!(/\A#(?:-\*-)?(.*)(?:-\*-)?/) {
+    e.src.script.sub!(/\A#(?:-\*-)?(.*)(?:-\*-)?/) {
       '# -*- \1; frozen-string-literal: true -*-'
     }
     assert_equal("a", e.result, bug12031)


### PR DESCRIPTION
This is still not 100% correct as trailing commands can take up an extra line.

In order to do this correctly, we'd need to adjust now commands are accumulated.

The current approach of using `line_count = content.count("\n")` can be improved by using a different syntax for strings.

https://github.com/ioquatix/trenni/blob/86394b0b9680e47eabd463317fac73c3a690b6cf/lib/trenni/template.rb#L70-L71 preserves newlines in the output correctly, which can make it easier to append content on the same line.