### PR TITLE
Enable frozen_string_literal in all files

### DIFF
--- a/lib/erb/compiler.rb
+++ b/lib/erb/compiler.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 #--
 # ERB::Compiler
 #

--- a/lib/erb/def_method.rb
+++ b/lib/erb/def_method.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 #--
 # ERB::DefMethod
 #

--- a/lib/erb/util.rb
+++ b/lib/erb/util.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 #--
 # ERB::Escape
 #


### PR DESCRIPTION
I was surprised to see erb show up when I was using memory_profiler on my app. ERB::Compiler#compile has a blank string literal, and it ended up allocating some 41532 blank strings for a relatively small surface area.