### PR TITLE
Add Ractor support

### DIFF
--- a/lib/erb.rb
+++ b/lib/erb.rb
@@ -353,7 +353,7 @@ class ERB
     @lineno = 0
     @_init = self.class.singleton_class
   end
-  NOT_GIVEN = Object.new
+  NOT_GIVEN = defined?(Ractor) ? Ractor.make_shareable(Object.new) : Object.new
   private_constant :NOT_GIVEN
 
   ##

--- a/lib/erb/compiler.rb
+++ b/lib/erb/compiler.rb
@@ -80,10 +80,16 @@ class ERB::Compiler # :nodoc:
   end
 
   class Scanner # :nodoc:
-    @scanner_map = {}
+    @scanner_map = defined?(Ractor) ? Ractor.make_shareable({}) : {}
     class << self
-      def register_scanner(klass, trim_mode, percent)
-        @scanner_map[[trim_mode, percent]] = klass
+      if defined?(Ractor)
+        def register_scanner(klass, trim_mode, percent)
+          @scanner_map = Ractor.make_shareable({ **@scanner_map, [trim_mode, percent] => klass })
+        end
+      else
+        def register_scanner(klass, trim_mode, percent)
+          @scanner_map[[trim_mode, percent]] = klass
+        end
       end
       alias :regist_scanner :register_scanner
     end


### PR DESCRIPTION
Hello,

I added some changes to `ruby/erb` to support Ractor.
- Make `ERB::NOT_GIVEN` ractor-shareable
- Make `@scanner_map` of `ERB::Compiler::Scanner` ractor-shareable
  - I referred https://github.com/ruby/did_you_mean/commit/8faba54b2d3ec9aa570691775f143801308c5b2f
  - Only main Ractor can call `ERB::Compiler::Scanner#register_scanner`

And I confirmed that:
- It doesn't affect to ERB's behavior with ruby-2.7.0 
- It allows us to call `ERB.new` and `ERB#result` in Ractor with ruby >= 3.1.0
- It can't allow us call `ERB#result` with ruby-3.0.x unfortunately
  - Because of the specification of Ractor on ruby-3.0.x:
    - "can not access instance variables of classes/modules from non-main Ractors"

```
$ for e in ALL_RUBY_BINS='ruby-2.5.0 ruby-2.6.0 ruby-2.7.0' ALL_RUBY_SINCE=ruby-3.0.0; do docker run -it -v .:/erb --rm rubylang/all-ruby env "$e" ./all-ruby -I/erb/lib -W0 -e 'begin; require "erb"; p [ERB.new("<%= 1 + 2 %>").result, defined?(Ractor) && Ractor.new { ERB.new("<%= 3 + 4 %>").result(binding) rescue [$!, $@[0]] }.take]; rescue; p $!; end'; done
ruby-2.5.0 #<NoMethodError: undefined method `resolve_feature_path' for #<Array:0x00005615de7f43e8>>
ruby-2.6.0 #<NoMethodError: undefined method `resolve_feature_path' for #<Array:0x000055faf5283390>>
ruby-2.7.0 ["3", nil]
ruby-3.0.0          ["3", [#<Ractor::IsolationError: can not access instance variables of classes/modules from non-main Ractors>, "/erb/lib/erb/compiler.rb:102:in `make_scanner'"]]
...
ruby-3.0.7          ["3", [#<Ractor::IsolationError: can not access instance variables of classes/modules from non-main Ractors>, "/erb/lib/erb/compiler.rb:102:in `make_scanner'"]]
ruby-3.1.0-preview1 ["3", "7"]
...
ruby-3.4.1          ["3", "7"]
```