### PR TITLE
erb.gemspec - only add cgi dependency when RUBY_VERSION < 3.5

### DIFF
--- a/erb.gemspec
+++ b/erb.gemspec
@@ -34,5 +34,7 @@ Gem::Specification.new do |spec|
     spec.extensions = ['ext/erb/escape/extconf.rb']
   end
 
-  spec.add_dependency 'cgi', '>= 0.3.3'
+  if RUBY_VERSION < '3.5'
+    spec.add_dependency 'cgi', '>= 0.3.3'
+  end
 end


### PR DESCRIPTION
The gemspec for cgi was removed in Ruby head (3.5), and this is causing many problems.  Unfortunately, many have been hidden.

Currently, https://github.com/ruby/ruby-dev-builder is failing, and has done so for 10 days, hence an older version is used in GHA  CI.  The failure is due to the command `rdoc -v` failing.  See the 'CLI Test' step [here](https://github.com/ruby/ruby-dev-builder/actions/runs/14948289174/job/41994488560#step:25:16).

The workflow hides the error, locally run:
```
/usr/local/lib/ruby/3.5.0+0/rubygems/specification.rb:1421:in 'block in Gem::Specification#activate_dependencies':
Could not find 'cgi' (>= 0.3.3) among 87 total gem(s) (Gem::MissingSpecError)
```

Also, a command line `ruby -rerb -e "puts 'Success'"` will fail.