### PR TITLE
Support all cgi.gem versions

### DIFF
--- a/erb.gemspec
+++ b/erb.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |spec|
   spec.summary       = %q{An easy to use but powerful templating system for Ruby.}
   spec.description   = %q{An easy to use but powerful templating system for Ruby.}
   spec.homepage      = 'https://github.com/ruby/erb'
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.5.0')
   spec.licenses      = ['Ruby', 'BSD-2-Clause']
 
   spec.metadata['homepage_uri'] = spec.homepage
@@ -27,10 +26,11 @@ Gem::Specification.new do |spec|
   spec.executables   = ['erb']
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = '>= 3.2.0'
+
   if RUBY_ENGINE == 'jruby'
     spec.platform = 'java'
   else
-    spec.required_ruby_version = '>= 2.7.0'
     spec.extensions = ['ext/erb/escape/extconf.rb']
   end
 end

--- a/lib/erb.rb
+++ b/lib/erb.rb
@@ -12,7 +12,6 @@
 #
 # You can redistribute it and/or modify it under the same terms as Ruby.
 
-require 'cgi/escape'
 require 'erb/version'
 require 'erb/compiler'
 require 'erb/def_method'

--- a/lib/erb/util.rb
+++ b/lib/erb/util.rb
@@ -1,5 +1,13 @@
 # frozen_string_literal: true
 
+# Load CGI.escapeHTML and CGI.escapeURIComponent.
+# CRuby:
+#   cgi.gem v0.1.0+ (Ruby 2.7-3.4) and Ruby 3.5+ stdlib have 'cgi/escape' and CGI.escapeHTML.
+#   cgi.gem v0.3.3+ (Ruby 3.2-3.4) and Ruby 3.5+ stdlib have CGI.escapeURIComponent.
+# JRuby: cgi.gem has a Java extension 'cgi/escape'.
+# TruffleRuby: lib/truffle/cgi/escape.rb requires 'cgi/util'.
+require 'cgi/escape'
+
 begin
   # We don't build the C extension for JRuby, TruffleRuby, and WASM
   if $LOAD_PATH.resolve_feature_path('erb/escape')
@@ -53,8 +61,16 @@ module ERB::Util
   #
   #   Programming%20Ruby%3A%20%20The%20Pragmatic%20Programmer%27s%20Guide
   #
-  def url_encode(s)
-    CGI.escapeURIComponent(s.to_s)
+  if CGI.respond_to?(:escapeURIComponent)
+    def url_encode(s)
+      CGI.escapeURIComponent(s.to_s)
+    end
+  else # cgi.gem <= v0.3.2
+    def url_encode(s)
+      s.to_s.b.gsub(/[^a-zA-Z0-9_\-.~]/n) do |m|
+        sprintf("%%%02X", m.unpack1("C"))
+      end
+    end
   end
   alias u url_encode
   module_function :u


### PR DESCRIPTION
Since https://bugs.ruby-lang.org/issues/21258, Ruby 3.5+ no longer ships cgi.gem. So we've removed the cgi.gem dependency from erb.gem https://github.com/ruby/erb/pull/59.

This PR adds the original implementation of `CGI.escapeURIComponent` before https://github.com/ruby/erb/pull/23 as a fallback in case cgi.gem v0.3.2 or older is used. The method was first added in cgi.gem v0.3.3.

This PR also bumps `required_ruby_version` to Ruby 3.2, which ships cgi.gem v0.3.6, to minimize the possibility of the fallback implementation used for CRuby. Note that Ruby 3.1 reached EOL on March 31st, 2025, so we're not obligated to support Ruby 3.1 or older anyway. The CI doesn't test those versions either.

I also added a comment to clarify why `require 'cgi/escape'` is enough for `ERB::Util`. erb.gem shouldn't need to `require 'cgi/util'`, which is warned in Ruby 3.5, even for TruffleRuby.