### PR TITLE
Refactor the logic of require 'erb/escape'

### DIFF
--- a/lib/erb/util.rb
+++ b/lib/erb/util.rb
@@ -8,14 +8,11 @@
 # TruffleRuby: lib/truffle/cgi/escape.rb requires 'cgi/util'.
 require 'cgi/escape'
 
-begin
-  # We don't build the C extension for JRuby, TruffleRuby, and WASM
-  if $LOAD_PATH.resolve_feature_path('erb/escape')
-    require 'erb/escape'
-  end
-rescue LoadError # resolve_feature_path raises LoadError on TruffleRuby 22.3.0
-end
-unless defined?(ERB::Escape)
+# Load or define ERB::Escape#html_escape.
+# We don't build the C extention 'cgi/escape' for JRuby, TruffleRuby, and WASM.
+if $LOAD_PATH.resolve_feature_path('erb/escape')
+  require 'erb/escape'
+else
   # ERB::Escape
   #
   # A subset of ERB::Util. Unlike ERB::Util#html_escape, we expect/hope


### PR DESCRIPTION
`$LOAD_PATH.resolve_feature_path` does not raise on Ruby 3.1+. Now that we require Ruby 3.2 https://github.com/ruby/erb/pull/60, we should be able to skip rescuing `LoadError`.