### PR TITLE
Forward-port ruby/ruby gemspec change

### DIFF
--- a/erb.gemspec
+++ b/erb.gemspec
@@ -2,7 +2,7 @@ begin
   require_relative 'lib/erb/version'
 rescue LoadError
   # for Ruby core repository
-  require_relative 'erb/version'
+  require_relative 'version'
 end
 
 Gem::Specification.new do |spec|


### PR DESCRIPTION
from https://github.com/ruby/ruby/pull/13754

```
Fixed inconsistency gemspec location

foo.gemspec should be located under the `lib/foo` directory if `lib/foo` is available
```

`ruby/erb` repository is not affected this change.