### PR TITLE
Potential escape optimization

### DIFF
--- a/ext/erb/escape/escape.c
+++ b/ext/erb/escape/escape.c
@@ -26,7 +26,68 @@ preserve_original_state(VALUE orig, VALUE dest)
 }
 
 static inline long
-escaped_length(VALUE str)
+escaped_length(const long len)
+{
+    if (len >= LONG_MAX / HTML_ESCAPE_MAX_LEN) {
+        ruby_malloc_size_overflow(len, HTML_ESCAPE_MAX_LEN);
+    }
+    return len * HTML_ESCAPE_MAX_LEN;
+}
+
+static inline VALUE
+optimized_escape_html(VALUE str, bool return_self)
+{
+    const char *cstr;
+    long str_len;
+    RSTRING_GETMEM(str, cstr, str_len);
+    const char *end = cstr + str_len;
+
+    while (cstr < end) {
+        const unsigned char c = *cstr;
+        if (html_escape_table[c].len) {
+            break;
+        }
+        cstr++;
+    }
+
+    if (cstr == end) {
+        // Nothing to escape.
+        if (return_self) {
+            return str;
+        }
+        return rb_str_dup(str);
+    }
+
+    VALUE vbuf;
+    const long remaining = end - cstr;
+    const long scanned = str_len - remaining;
+    char *buf = ALLOCV_N(char, vbuf, scanned + escaped_length(remaining));
+    memcpy(buf, RSTRING_PTR(str), scanned);
+
+    char *dest = buf + scanned;
+    while (cstr < end) {
+        const unsigned char c = *cstr++;
+        uint8_t len = html_escape_table[c].len;
+        if (len) {
+            memcpy(dest, html_escape_table[c].str, len);
+            dest += len;
+        }
+        else {
+            *dest++ = c;
+        }
+    }
+
+    VALUE escaped = str;
+    if (RSTRING_LEN(str) < (dest - buf)) {
+        escaped = rb_str_new(buf, dest - buf);
+        preserve_original_state(str, escaped);
+    }
+    ALLOCV_END(vbuf);
+    return escaped;
+}
+
+static inline long
+old_escaped_length(VALUE str)
 {
     const long len = RSTRING_LEN(str);
     if (len >= LONG_MAX / HTML_ESCAPE_MAX_LEN) {
@@ -36,10 +97,10 @@ escaped_length(VALUE str)
 }
 
 static VALUE
-optimized_escape_html(VALUE str)
+old_optimized_escape_html(VALUE str)
 {
     VALUE vbuf;
-    char *buf = ALLOCV_N(char, vbuf, escaped_length(str));
+    char *buf = ALLOCV_N(char, vbuf, old_escaped_length(str));
     const char *cstr = RSTRING_PTR(str);
     const char *end = cstr + RSTRING_LEN(str);
 
@@ -79,7 +140,37 @@ erb_escape_html(VALUE self, VALUE str)
     }
 
     if (rb_enc_str_asciicompat_p(str)) {
-        return optimized_escape_html(str);
+        return optimized_escape_html(str, false);
+    }
+    else {
+        return rb_funcall(rb_cCGI, id_escapeHTML, 1, str);
+    }
+}
+
+static VALUE
+erb_escape_html_bang(VALUE self, VALUE str)
+{
+    if (!RB_TYPE_P(str, T_STRING)) {
+        str = rb_convert_type(str, T_STRING, "String", "to_s");
+    }
+
+    if (rb_enc_str_asciicompat_p(str)) {
+        return optimized_escape_html(str, true);
+    }
+    else {
+        return rb_funcall(rb_cCGI, id_escapeHTML, 1, str);
+    }
+}
+
+static VALUE
+old_erb_escape_html(VALUE self, VALUE str)
+{
+    if (!RB_TYPE_P(str, T_STRING)) {
+        str = rb_convert_type(str, T_STRING, "String", "to_s");
+    }
+
+    if (rb_enc_str_asciicompat_p(str)) {
+        return old_optimized_escape_html(str);
     }
     else {
         return rb_funcall(rb_cCGI, id_escapeHTML, 1, str);
@@ -96,6 +187,8 @@ Init_escape(void)
     rb_cERB = rb_define_class("ERB", rb_cObject);
     rb_mEscape = rb_define_module_under(rb_cERB, "Escape");
     rb_define_module_function(rb_mEscape, "html_escape", erb_escape_html, 1);
+    rb_define_module_function(rb_mEscape, "html_escape!", erb_escape_html_bang, 1);
+    rb_define_module_function(rb_mEscape, "old_html_escape", old_erb_escape_html, 1);
 
     rb_cCGI = rb_define_class("CGI", rb_cObject);
     id_escapeHTML = rb_intern("escapeHTML");

--- a/lib/erb/util.rb
+++ b/lib/erb/util.rb
@@ -47,6 +47,10 @@ module ERB::Util
   alias h html_escape
   module_function :h
 
+  module_function :html_escape!
+  alias h! html_escape!
+  module_function :h!
+
   #
   # A utility method for encoding the String _s_ as a URL.
   #


### PR DESCRIPTION
Opening as a draft, to gauge your interest first.

One part of the PR is a fairly straightforward optimization, if we assume most strings don't need escaping we can save lots of work by optimistically scanning it it first.

I think this assumption is fair, given how ERB is used nowadays, where all interpolated strings are escaped, so aside from rare cases, only a minority need to be escaped.

If we take this assumption further, having to dup the string even when it's already safe is wasteful. So another API (currently `html_escape!`, but any name would do) which return the same string if escaping wasn't needed.

Given in the context of ERB interpolation, the code end up as `buffer << ERB::Util.escape(title)`, there's no need to dup to avoid mutation.

@k0kubun any opinions? Do you want me to cleanup either or both of these changes?

```
ruby 3.4.2 (2025-02-15 revision d2930f8e7a) +PRISM [arm64-darwin24]
Warming up --------------------------------------
              before     1.364M i/100ms
               after     1.909M i/100ms
                bang     2.829M i/100ms
Calculating -------------------------------------
              before     13.660M (± 0.3%) i/s   (73.21 ns/i) -     69.550M in   5.091551s
               after     19.157M (± 0.4%) i/s   (52.20 ns/i) -     97.340M in   5.081359s
                bang     28.330M (± 0.6%) i/s   (35.30 ns/i) -    144.274M in   5.092794s

Comparison:
              before: 13660076.4 i/s
                bang: 28329932.0 i/s - 2.07x  faster
               after: 19156538.1 i/s - 1.40x  faster

ruby 3.4.2 (2025-02-15 revision d2930f8e7a) +PRISM [arm64-darwin24]
Warming up --------------------------------------
              before     1.138M i/100ms
               after     1.400M i/100ms
                bang     1.411M i/100ms
Calculating -------------------------------------
              before     11.367M (± 4.0%) i/s   (87.97 ns/i) -     56.900M in   5.016941s
               after     13.935M (± 0.6%) i/s   (71.76 ns/i) -     69.980M in   5.022190s
                bang     13.884M (± 0.4%) i/s   (72.02 ns/i) -     70.552M in   5.081496s

Comparison:
              before: 11366937.1 i/s
               after: 13934530.2 i/s - 1.23x  faster
                bang: 13884325.4 i/s - 1.22x  faster
```

```
require 'bundler/inline'
gemfile do
  gem 'erb', path: "."
  gem 'benchmark-ips'
end

require 'benchmark/ips'
require 'erb'
require 'erb/escape'

class << ERB::Util
  def html_escape_old(s)
    CGI.escapeHTML(s.to_s)
  end
end

Benchmark.ips do |x|
  s = 'hello world'
  x.report('before') { ERB::Util.html_escape_old(s) }
  x.report('after')  { ERB::Util.html_escape(s) }
  x.report('bang')  { ERB::Util.html_escape!(s) }
  x.compare!(order: :baseline)
end

Benchmark.ips do |x|
  s = 'hello wo<ld'
  x.report('before') { ERB::Util.html_escape_old(s) }
  x.report('after')  { ERB::Util.html_escape(s) }
  x.report('bang')  { ERB::Util.html_escape!(s) }
  x.compare!(order: :baseline)
end
```