### PR TITLE
[DOC] Fix the description of #new_toplevel

### DIFF
--- a/lib/erb.rb
+++ b/lib/erb.rb
@@ -999,8 +999,9 @@ class ERB
   # See [Default Binding][default binding].
   #
   # Argument `symbols` is an array of symbols;
-  # each symbol `symbol` is used to define (unless already defined) a variable in the binding
-  # whose name is `symbol` and whose value is `nil`.
+  # each symbol `symbol` is defined as a new variable to hide and
+  # prevent it from overwriting a variable of the same name already
+  # defined within the binding.
   #
   # [default binding]: rdoc-ref:ERB@Default+Binding
   def new_toplevel(vars = nil)


### PR DESCRIPTION
`new_toplevel` does not define new variables that is not defined already in the binding.

```ruby
require 'erb'
e = ERB.new("")
b = e.send(:new_toplevel, [:x])
p b.local_variable_get(:x) #=> NameError, local variable 'x' is not defined
```

Conversely, hides the variables that have already been defined.

```ruby
require 'erb'
e = ERB.new("")
b = e.send(:new_toplevel, [])
p b.local_variable_get(:b) == b #=> true
b = e.send(:new_toplevel, [:b])
p b.local_variable_get(:b)      #=> nil
```