### PR TITLE
chore: fix dead link to now removed issue

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -57,7 +57,7 @@
 
 ## 4.0.4
 
-* Skip building the C extension for JRuby [#52](https://github.com/ruby/erb/pull/52)
+* Skip building the C extension for JRuby
 
 ## 4.0.3
 


### PR DESCRIPTION
Fixes dead link in NEWS.

I understand you were probably trying to stop people filing issues in the places you don't want them; but it has presumably had the side effect of taking all history offline and breaking links like this (to an issue, not a PR) as well as removing important context for some changes PRs.

There's seemingly no way to find any context for the change now, since the issues have been made "closed source" and the commit message at https://github.com/ruby/erb/commit/f0f68baf6ba153395b2a4589f30d16c9a5a37d7e contains no context. As an additional example, https://github.com/ruby/erb/pull/38 also has no context and links to https://github.com/ruby/erb/issues/32 which is now dead. IMHO this is not good.

For the record, as a community member who spends a lot of time doing code archaeology and digging around projects, I really dislike it when projects do this in GitHub. I  don't think this is/was a good idea and is against the spirit of open source - because it closes access to information that _was_ open/public and summarily takes others' public contributions private.