### PR TITLE
chore: forward-port NEWS/changelog entries for clarity

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,10 @@
 
 * Freeze `src` in `ERB#initialize` for Ractor compatibility https://github.com/ruby/erb/pull/105
 
+## 6.0.1.1
+
+* Prohibit `def_method` on marshal-loaded ERB instances
+
 ## 6.0.1
 
 * Freeze `ERB::Compiler::TrimScanner::ERB_STAG` for Ractor compatibility
@@ -55,9 +59,17 @@
 * Drop `cgi` from runtime dependencies [#59](https://github.com/ruby/erb/pull/59)
 * Make `ERB::VERSION` public
 
+## 4.0.4.1
+
+* Prohibit `def_method` on marshal-loaded ERB instances
+
 ## 4.0.4
 
 * Skip building the C extension for JRuby [#52](https://github.com/ruby/erb/pull/52)
+
+## 4.0.3.1
+
+* Prohibit `def_method` on marshal-loaded ERB instances
 
 ## 4.0.3
 


### PR DESCRIPTION
Consolidates changelog entries from earlier ruby branches making it easier to see the entire history in one place.
- 93450765b5319cfb552a3d9719df137e8fbb75e9
- 6a2e4a76d352127135359e3420d5f42b767a0600
- b6be29fd0e0f5089447d2f8d18140ae78258621d

As a side note, I see all the historical branches have been deleted. I understand that Ruby 3.1 is EOL from CRuby PoV, however JRuby `9.4` targets Ruby `3.1` compatibility, and is just about to go soft EOL itself.

It thus targets erb `2.2.3`. Would you consider doing a one-off `2.2.3.1` release? https://github.com/ruby/erb/compare/v2.2.3...chadlwilson:erb:ruby-3.1 (tests pass locally on CRuby 3.1 and JRuby 9.4)

Otherwise I suppose jruby can consider deviating stdlib verisons and bumping to `4.0.3.1` or `4.0.4.1` (which is probably fine?)