### PR TITLE
Constrain RDoc below 8 for JRuby CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec
 group :development do
   gem 'rake'
   gem 'rake-compiler'
-  gem 'rdoc'
+  gem 'rdoc', '< 8'
   gem 'test-unit'
   gem "test-unit-ruby-core"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,12 @@ gemspec
 group :development do
   gem 'rake'
   gem 'rake-compiler'
-  gem 'rdoc', '< 8'
+  if RUBY_ENGINE == 'jruby'
+    # RDoc 8 pulls in RBS 4, which attempts to build a native extension on JRuby.
+    gem 'rdoc', '< 8'
+  else
+    gem 'rdoc'
+  end
   gem 'test-unit'
   gem "test-unit-ruby-core"
 end


### PR DESCRIPTION
RDoc 8 resolves RBS 4, which attempts to build a native extension under JRuby and breaks the Dependabot test workflow before tests run.

This caps the development RDoc dependency below 8 so the JRuby matrix can install dependencies again while keeping RDoc coverage enabled.