### PR TITLE
Fix wrong receiver in eoutvar example for #src

### DIFF
--- a/lib/erb.rb
+++ b/lib/erb.rb
@@ -889,7 +889,7 @@ class ERB
   #
   # ```
   # erb = ERB.new(template, eoutvar: '_foo')
-  # puts template.src.split('; ')
+  # puts erb.src.split('; ')
   # #coding:UTF-8
   # _foo = +''
   # _foo.<< "The time is ".freeze


### PR DESCRIPTION
The second example in the documentation for `#src` raises NoMethodError as written. When the example was changed to assign the ERB instance to `erb` instead of `template`, the next line was left calling `template.src`, but `template` is a String at that point. This fixes the receiver to `erb`.

I ran the corrected example and confirmed it produces exactly the output shown in the documentation.
