### PR TITLE
Avoid dispatch in ERB initialization guard

### DIFF
--- a/lib/erb.rb
+++ b/lib/erb.rb
@@ -778,6 +778,9 @@ require 'erb/util'
 # [template processor]: https://en.wikipedia.org/wiki/Template_processor
 #
 class ERB
+  IDENTITY_METHOD = BasicObject.instance_method(:equal?)
+  private_constant :IDENTITY_METHOD
+
   # :markup: markdown
   #
   # :call-seq:
@@ -1007,7 +1010,7 @@ class ERB
   # [local binding]: rdoc-ref:ERB@Local+Binding
   #
   def result(b=new_toplevel)
-    unless @_init.equal?(self.class.singleton_class)
+    unless initialized_by_new?
       raise ArgumentError, "not initialized"
     end
     eval(@src, b, (@filename || '(erb)'), @lineno)
@@ -1061,6 +1064,11 @@ class ERB
   end
   private :new_toplevel
 
+  def initialized_by_new?
+    IDENTITY_METHOD.bind_call(@_init, self.class.singleton_class)
+  end
+  private :initialized_by_new?
+
   # :markup: markdown
   #
   # :call-seq:
@@ -1087,7 +1095,7 @@ class ERB
   # ```
   #
   def def_method(mod, methodname, fname='(ERB)')
-    unless @_init.equal?(self.class.singleton_class)
+    unless initialized_by_new?
       raise ArgumentError, "not initialized"
     end
     src = self.src.sub(/^(?!#|$)/) {"def #{methodname}\n"} << "\nend\n"

--- a/lib/erb.rb
+++ b/lib/erb.rb
@@ -778,7 +778,7 @@ require 'erb/util'
 # [template processor]: https://en.wikipedia.org/wiki/Template_processor
 #
 class ERB
-  IDENTITY_METHOD = BasicObject.instance_method(:equal?)
+  IDENTITY_METHOD = BasicObject.instance_method(:equal?) # :nodoc:
   private_constant :IDENTITY_METHOD
 
   # :markup: markdown
@@ -1064,7 +1064,7 @@ class ERB
   end
   private :new_toplevel
 
-  def initialized_by_new?
+  def initialized_by_new? # :nodoc:
     IDENTITY_METHOD.bind_call(@_init, self.class.singleton_class)
   end
   private :initialized_by_new?

--- a/test/erb/test_erb.rb
+++ b/test/erb/test_erb.rb
@@ -85,8 +85,22 @@ class TestERB < Test::Unit::TestCase
 end
 
 class TestERBCore < Test::Unit::TestCase
+  class AlwaysEqual
+    def equal?(_other)
+      true
+    end
+  end
+
   def setup
     @erb = ERB
+  end
+
+  def marshal_loaded_erb(init, src: "")
+    erb = ERB.allocate
+    erb.instance_variable_set(:@src, src)
+    erb.instance_variable_set(:@lineno, 1)
+    erb.instance_variable_set(:@_init, init)
+    Marshal.load(Marshal.dump(erb))
   end
 
   def test_version
@@ -664,12 +678,22 @@ EOS
     assert_raise(ArgumentError) {erb.result}
   end
 
+  def test_prohibited_marshal_load_result_with_overridden_equal
+    erb = marshal_loaded_erb(AlwaysEqual.new, src: "raise 'unreachable'")
+    assert_raise(ArgumentError) {erb.result}
+  end
+
   def test_prohibited_marshal_load_def_method
     erb = ERB.allocate
     erb.instance_variable_set(:@src, "")
     erb.instance_variable_set(:@lineno, 1)
     erb.instance_variable_set(:@_init, true)
     erb = Marshal.load(Marshal.dump(erb))
+    assert_raise(ArgumentError) {erb.def_method(Class.new, 'render')}
+  end
+
+  def test_prohibited_marshal_load_def_method_with_overridden_equal
+    erb = marshal_loaded_erb(AlwaysEqual.new)
     assert_raise(ArgumentError) {erb.def_method(Class.new, 'render')}
   end
 


### PR DESCRIPTION
The guard for methods that eval ERB source compared @_init with self.class.singleton_class by calling equal? on @_init. A marshal-loaded object can control @_init, so make the comparison through BasicObject#equal? directly instead of dispatching to the restored object.

This keeps normal ERB instances working while preserving the ArgumentError for marshal-loaded instances.