### PR TITLE
Fix `-h` CLI option

### DIFF
--- a/libexec/erb
+++ b/libexec/erb
@@ -89,7 +89,7 @@ class ERB
             set_encoding(Encoding::UTF_8, Encoding::UTF_8)
           when '-P'
             disable_percent = true
-          when '--help'
+          when '-h', '--help'
             raise ''
           when /\A-/
             raise "Unknown switch: #{switch.dump}"


### PR DESCRIPTION
Fixes the `Unknown switch: "-h"` error message when running `erb -h`:

```sh-session
$ libexec/erb -h 2>&1 | head -3
Unknown switch: "-h"
Usage:
  erb [options] [filepaths]
```

The short `-h` option is already documented in the help message:

```sh-session
$ libexec/erb --help 2>&1 | grep 'help'
  -h          --help       Print this text and exit.
```