### PR TITLE
Fix Ractor compatibility regression, add tests

### DIFF
--- a/lib/erb.rb
+++ b/lib/erb.rb
@@ -815,9 +815,6 @@ require 'erb/util'
 # [template processor]: https://en.wikipedia.org/wiki/Template_processor
 #
 class ERB
-  IDENTITY_METHOD = BasicObject.instance_method(:equal?) # :nodoc:
-  private_constant :IDENTITY_METHOD
-
   # :markup: markdown
   #
   # :call-seq:
@@ -1117,7 +1114,7 @@ class ERB
   private :new_toplevel
 
   def initialized_by_new? # :nodoc:
-    IDENTITY_METHOD.bind_call(@_init, self.class.singleton_class)
+    self.class.singleton_class.equal? @_init
   end
   private :initialized_by_new?
 

--- a/lib/erb/compiler.rb
+++ b/lib/erb/compiler.rb
@@ -80,16 +80,11 @@ class ERB::Compiler # :nodoc:
   end
 
   class Scanner # :nodoc:
-    @scanner_map = defined?(Ractor) ? Ractor.make_shareable({}) : {}
+    @scanner_map = {}.freeze
+
     class << self
-      if defined?(Ractor)
-        def register_scanner(klass, trim_mode, percent)
-          @scanner_map = Ractor.make_shareable({ **@scanner_map, [trim_mode, percent] => klass })
-        end
-      else
-        def register_scanner(klass, trim_mode, percent)
-          @scanner_map[[trim_mode, percent]] = klass
-        end
+      def register_scanner(klass, trim_mode, percent)
+        @scanner_map = @scanner_map.merge([trim_mode, percent].freeze => klass).freeze
       end
       alias :regist_scanner :register_scanner
     end

--- a/test/erb/test_erb.rb
+++ b/test/erb/test_erb.rb
@@ -740,3 +740,43 @@ class TestERBCoreWOStrScan < TestERBCore
     ERB::Compiler::Scanner.instance_variable_set('@scanner_map', @save_map)
   end
 end
+
+class TestERBRactor < Test::Unit::TestCase
+  def test_compile_and_result_in_ractor
+    assert_ractor(<<~RUBY, require: 'erb')
+      r = Ractor.new do
+        ERB.new("Hello, <%= 'world' %>!").result(binding)
+      end
+      assert_equal("Hello, world!", r.value)
+    RUBY
+  end
+
+  def test_trim_mode_in_ractor
+    assert_ractor(<<~RUBY, require: 'erb')
+      src = "<% [1, 2].each do |i| %>\\n<%= i %>\\n<% end %>\\n"
+      r = Ractor.new(src) { |s| ERB.new(s, trim_mode: '-').result(binding) }
+      assert_equal("\\n1\\n\\n2\\n\\n", r.value)
+
+      r = Ractor.new(src) { |s| ERB.new(s, trim_mode: '<>').result(binding) }
+      assert_equal("12", r.value)
+    RUBY
+  end
+
+  def test_frozen_erb_instance_reused_across_ractors
+    assert_ractor(<<~RUBY, require: 'erb')
+      erb = ERB.new("<%= 1 + 1 %>")
+      erb.freeze
+      rs = 2.times.map { Ractor.new(erb) { |e| e.result(binding) } }
+      assert_equal(["2", "2"], rs.map(&:value))
+    RUBY
+  end
+
+  def test_util_html_escape_in_ractor
+    assert_ractor(<<~RUBY, require: 'erb')
+      r = Ractor.new do
+        ERB::Util.html_escape("<script>")
+      end
+      assert_equal("&lt;script&gt;", r.value)
+    RUBY
+  end
+end


### PR DESCRIPTION
The recent change to use `BasicObject.instance_method(:equal?)` broke
the ability to share frozen ERB templates across Ractors because
`UnboundMethod` isn't shareable.

Freezing the `UnboundMethod` _may_ fix the issue (dependong on Ruby
version), but replacing the constant with an inline call to the
`singleton_class` is simpler (and still avoids calling `equal?` on
`@init`).

There have previously been many contributions to make ERB Ractor safe,
but no tests added to ensure it continues to be Ractor safe, so this
commit also adds some regression tests.

---

[Simplify Scanner's Ractor safety code](https://github.com/ruby/erb/commit/c34cd4b6037b3a7b1d95d0ba3740c2b4ebf2771b) 

Ractor.make_shareable isn't needed if everything is plain `freeze`d