### PR TITLE
Consume attached erb option arguments once

### DIFF
--- a/libexec/erb
+++ b/libexec/erb
@@ -15,14 +15,17 @@ class ERB
       when /\A-(.)(.*)/
         if $1 == '-'
           arg, @maybe_arg = arg.split(/=/, 2)
+          @maybe_arg_from_short = false
           return arg
         end
         raise 'unknown switch "-"' if $2[0] == ?- and $1 != 'T'
         if $2.size > 0
           self.unshift "-#{$2}"
           @maybe_arg = $2
+          @maybe_arg_from_short = true
         else
           @maybe_arg = nil
+          @maybe_arg_from_short = false
         end
         "-#{$1}"
       when /\A(\w+)=/
@@ -34,9 +37,17 @@ class ERB
     end
 
     def ARGV.req_arg
-      (@maybe_arg || self.shift || raise('missing argument')).tap {
+      begin
+        if @maybe_arg
+          self.shift if @maybe_arg_from_short
+          @maybe_arg
+        else
+          self.shift || raise('missing argument')
+        end
+      ensure
         @maybe_arg = nil
-      }
+        @maybe_arg_from_short = false
+      end
     end
 
     def trim_mode_opt(trim_mode, disable_percent)


### PR DESCRIPTION
Dequeues an attached short-option tail when req_arg consumes it, so documented forms such as -T1, -EUTF-8, -rjson, and clustered -xT1 are not parsed a second time as unknown switches.

Verified with all four CLI forms and the compiled-native 54-test / 157-assertion suite.