### PR TITLE
Speedup `ERB::Util.html_escape` with SIMD

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/Gemfile
+++ b/Gemfile
@@ -13,4 +13,5 @@ group :development do
   end
   gem 'test-unit'
   gem "test-unit-ruby-core"
+  gem 'benchmark-ips'
 end

--- a/benchmark/escape.rb
+++ b/benchmark/escape.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'benchmark/ips'
+require 'fileutils'
+require 'erb'
+
+DATA_DIR = "/tmp/erb-bench"
+
+def bench(name, string)
+  puts "== #{name} =="
+  Benchmark.ips do |x|
+    x.report(ENV["BRANCH"] || "current") { ERB::Util.html_escape(string) }
+    if ENV["BRANCH"]
+      FileUtils.mkdir_p(DATA_DIR)
+      x.compare!(order: :baseline)
+      x.save!(File.join(DATA_DIR, "#{name.tr(" ", "-")}.data"))
+    end
+  end
+  puts
+end
+
+bench("1k no matches", ("a" * 1024).freeze)
+bench("1k few matches", (("a" * 127 + "<") * 8).freeze)
+bench("1k many matches", (("a" * 31 + "<") * 32).freeze)

--- a/ext/erb/escape/escape.c
+++ b/ext/erb/escape/escape.c
@@ -35,37 +35,244 @@ escaped_length(VALUE str)
     return len * HTML_ESCAPE_MAX_LEN;
 }
 
+#ifdef __clang__
+# if __has_builtin(__builtin_ctzll)
+#   define HAVE_BUILTIN_CTZLL 1
+# else
+#   define HAVE_BUILTIN_CTZLL 0
+# endif
+#elif defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 3))
+# define HAVE_BUILTIN_CTZLL 1
+#else
+# define HAVE_BUILTIN_CTZLL 0
+#endif
+
+#ifdef ERB_ENABLE_SIMD
+#if defined(__amd64__) || defined(__amd64) || defined(__x86_64__) || defined(__x86_64) || defined(_M_X64) || defined(_M_AMD64)
+#ifdef HAVE_X86INTRIN_H
+#include <x86intrin.h>
+#define HAVE_SIMD 1
+#define HAVE_SIMD_SSE2 1
+#endif
+#endif
+
+#if defined(__ARM_NEON) || defined(__ARM_NEON__) || defined(__aarch64__) || defined(_M_ARM64)
+#define HAVE_SIMD 1
+#define HAVE_SIMD_NEON 1
+#include <arm_neon.h>
+#endif
+#endif // ERB_ENABLE_SIMD
+
+typedef struct _search_state {
+    const unsigned char *cstr;
+    const unsigned char *end;
+
+#if defined(HAVE_SIMD_NEON)
+    uint64_t matches_bitmap;
+#elif defined(HAVE_SIMD_SSE2)
+    int matches_bitmap;
+#endif
+} search_state;
+
+static inline bool
+find_next_basic(search_state *search)
+{
+    while (search->cstr < search->end) {
+        const unsigned char c = *search->cstr;
+        if (html_escape_table[c].len) {
+            return true;
+        }
+        search->cstr++;
+    }
+    return false;
+}
+
+#ifdef HAVE_SIMD_SSE2
+
+static inline int trailing_zeros(int input)
+{
+    RUBY_ASSERT(input > 0); // __builtin_ctz(0) is undefined behavior
+
+#if HAVE_BUILTIN_CTZLL
+    return __builtin_ctz(input);
+#else
+    int trailing_zeros = 0;
+    int temp = input;
+    while ((temp & 1) == 0 && temp > 0) {
+        trailing_zeros++;
+        temp >>= 1;
+    }
+    return trailing_zeros;
+#endif
+}
+
+static inline bool
+find_next_match_sse2(search_state *search)
+{
+    int next_match_offset = trailing_zeros(search->matches_bitmap);
+    search->matches_bitmap >>= (next_match_offset + 1);
+    search->cstr += next_match_offset;
+    if (search->cstr > search->end) {
+        search->cstr = search->end;
+        return false;
+    }
+    return true;
+}
+
+static inline bool
+find_next_sse2(search_state *search)
+{
+    if (search->matches_bitmap) {
+        return find_next_match_sse2(search);
+    }
+
+    const __m128i single_quote = _mm_set1_epi8('\'');
+    const __m128i double_quote = _mm_set1_epi8('"');
+    const __m128i ampersand = _mm_set1_epi8('&');
+    const __m128i lt = _mm_set1_epi8('<');
+    const __m128i gt = _mm_set1_epi8('>');
+
+    while ((size_t)(search->end - search->cstr) >= sizeof(__m128i)) {
+        const __m128i bytes = _mm_loadu_si128((__m128i const *)search->cstr);
+        const __m128i match1 = _mm_cmpeq_epi8(bytes, single_quote);
+        const __m128i match2 = _mm_cmpeq_epi8(bytes, double_quote);
+        const __m128i match3 = _mm_cmpeq_epi8(bytes, ampersand);
+        const __m128i match4 = _mm_cmpeq_epi8(bytes, lt);
+        const __m128i match5 = _mm_cmpeq_epi8(bytes, gt);
+
+        const __m128i mask1 = _mm_or_si128(match1, match2);
+        const __m128i mask2 = _mm_or_si128(match3, match4);
+        const __m128i mask3 = _mm_or_si128(mask1, match5);
+        const __m128i matches = _mm_or_si128(mask2, mask3);
+
+        const int bitmap = _mm_movemask_epi8(matches);
+
+        if (bitmap) {
+            search->matches_bitmap = bitmap;
+            return find_next_match_sse2(search);
+        }
+        search->cstr += sizeof(__m128i);
+    }
+
+    return find_next_basic(search);
+}
+#define find_next find_next_sse2
+#endif
+
+#ifdef HAVE_SIMD_NEON
+#ifndef __has_builtin         // Optional of course.
+  #define __has_builtin(x) 0  // Compatibility with non-clang compilers.
+#endif
+
+static inline uint32_t trailing_zeros64(uint64_t input)
+{
+#if HAVE_BUILTIN_CTZLL
+    return __builtin_ctzll(input);
+#else
+    uint32_t trailing_zeros = 0;
+    uint64_t temp = input;
+    while ((temp & 1) == 0 && temp > 0) {
+        trailing_zeros++;
+        temp >>= 1;
+    }
+    return trailing_zeros;
+#endif
+}
+
+static inline bool
+find_next_match_neon(search_state *search)
+{
+    size_t next_match_offset = trailing_zeros64(search->matches_bitmap) / 4;
+    search->matches_bitmap >>= (next_match_offset + 1) * 4;
+    search->cstr += next_match_offset;
+    if (search->cstr > search->end) {
+        search->cstr = search->end;
+        return false;
+    }
+    return true;
+}
+
+static inline bool
+find_next_neon(search_state *search)
+{
+    if (search->matches_bitmap) {
+        return find_next_match_neon(search);
+    }
+
+    const uint8x16_t single_quote = vdupq_n_u8('\'');
+    const uint8x16_t double_quote = vdupq_n_u8('"');
+    const uint8x16_t ampersand = vdupq_n_u8('&');
+    const uint8x16_t lt = vdupq_n_u8('<');
+    const uint8x16_t gt = vdupq_n_u8('>');
+
+    while ((size_t)(search->end - search->cstr) >= sizeof(uint8x16_t)) {
+        const uint8x16_t bytes = vld1q_u8(search->cstr);
+        const uint8x16_t match1 = vceqq_u8(bytes, single_quote);
+        const uint8x16_t match2 = vceqq_u8(bytes, double_quote);
+        const uint8x16_t match3 = vceqq_u8(bytes, ampersand);
+        const uint8x16_t match4 = vceqq_u8(bytes, lt);
+        const uint8x16_t match5 = vceqq_u8(bytes, gt);
+
+        const uint8x16_t mask1 = vorrq_u8(match1, match2);
+        const uint8x16_t mask2 = vorrq_u8(match3, match4);
+        const uint8x16_t mask3 = vorrq_u8(mask1, match5);
+        const uint8x16_t matches = vorrq_u8(mask2, mask3);
+
+        const uint8x8_t res = vshrn_n_u16(vreinterpretq_u16_u8(matches), 4);
+        const uint64_t bitmap = vget_lane_u64(vreinterpret_u64_u8(res), 0) & 0x8888888888888888ull;
+
+        if (bitmap) {
+            search->matches_bitmap = bitmap;
+            return find_next_match_neon(search);
+        }
+        search->cstr += sizeof(uint8x16_t);
+    }
+
+    return find_next_basic(search);
+}
+
+#define find_next find_next_neon
+#endif // HAVE_SIMD_NEON
+
+#ifndef find_next
+#define find_next_basic
+#endif
+
 static VALUE
 optimized_escape_html(VALUE str)
 {
     VALUE vbuf;
     char *buf = NULL;
-    const char *cstr = RSTRING_PTR(str);
-    const char *end = cstr + RSTRING_LEN(str);
+    search_state search = {
+        .cstr = (const unsigned char *)RSTRING_PTR(str),
+    };
+    search.end = search.cstr + RSTRING_LEN(str);
 
-    const char *segment_start = cstr;
+    const unsigned char *segment_start = search.cstr;
     char *dest = NULL;
-    while (cstr < end) {
-        const unsigned char c = *cstr++;
+
+    while (find_next(&search)) {
+        const unsigned char c = *search.cstr;
         uint8_t len = html_escape_table[c].len;
-        if (len) {
-            size_t segment_len = cstr - segment_start - 1;
-            if (!buf) {
-                buf = ALLOCV_N(char, vbuf, escaped_length(str));
-                dest = buf;
-            }
-            if (segment_len) {
-                memcpy(dest, segment_start, segment_len);
-                dest += segment_len;
-            }
-            segment_start = cstr;
-            memcpy(dest, html_escape_table[c].str, len);
-            dest += len;
+        size_t segment_len = search.cstr - segment_start;
+        search.cstr++;
+
+        if (!buf) {
+            buf = ALLOCV_N(char, vbuf, escaped_length(str));
+            dest = buf;
         }
+        if (segment_len) {
+            memcpy(dest, segment_start, segment_len);
+            dest += segment_len;
+        }
+        segment_start = search.cstr;
+        memcpy(dest, html_escape_table[c].str, len);
+        dest += len;
     }
+
     VALUE escaped = str;
     if (buf) {
-        size_t segment_len = cstr - segment_start;
+        size_t segment_len = search.cstr - segment_start;
         if (segment_len) {
             memcpy(dest, segment_start, segment_len);
             dest += segment_len;

--- a/ext/erb/escape/extconf.rb
+++ b/ext/erb/escape/extconf.rb
@@ -5,5 +5,27 @@ when 'jruby', 'truffleruby'
   File.write('Makefile', dummy_makefile($srcdir).join)
 else
   have_func("rb_ext_ractor_safe", "ruby.h")
+
+  case RbConfig::CONFIG['host_cpu']
+  when /^(arm|aarch64)/
+    # Try to compile a small program using NEON instructions
+    header, type, init, extra = 'arm_neon.h', 'uint8x16_t', 'vdupq_n_u8(32)', nil
+  when /^(x86_64|x64)/
+    header, type, init, extra = 'x86intrin.h', '__m128i', '_mm_set1_epi8(32)', 'if (__builtin_cpu_supports("sse2")) { printf("OK"); }'
+  end
+  if header
+    if have_header(header) && try_compile(<<~SRC, '-Werror=implicit-function-declaration')
+        #{cpp_include(header)}
+        int main(int argc, char **argv) {
+          #{type} test = #{init};
+          #{extra}
+          if (argc > 100000) printf("%p", &test);
+          return 0;
+        }
+      SRC
+      $defs.push("-DERB_ENABLE_SIMD")
+    end
+  end
+
   create_makefile 'erb/escape'
 end

--- a/test/erb/test_erb.rb
+++ b/test/erb/test_erb.rb
@@ -50,7 +50,7 @@ class TestERB < Test::Unit::TestCase
     assert_equal("", ERB::Util.html_escape(""))
     assert_equal("abc", ERB::Util.html_escape("abc"))
     assert_equal("&lt;&lt;", ERB::Util.html_escape("<\<"))
-    assert_equal("&#39;&amp;&quot;&gt;&lt;", ERB::Util.html_escape("'&\"><"))
+    assert_equal("&#39;&amp;&quot;&gt;&lt;" * 10, ERB::Util.html_escape("'&\"><" * 10))
 
     assert_equal("", ERB::Util.html_escape(nil))
     assert_equal("123", ERB::Util.html_escape(123))


### PR DESCRIPTION
The code is lifted from similar work in the `json` gem. SIMD use is limited to NEON and SSE2 as they can easily be detected and assumed at compile time.

Using more advanced SIMD implementations would require runtime detection, which probably isn't worth it.

Unsurprisingly, the gains are huge when large portions of the string don't contain anything to escape, but much more modest when it has to frequently stop to copy bytes and escape:

```
== 1k no matches ==
ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +YJIT +PRISM [arm64-darwin25]
Warming up --------------------------------------
                simd     1.430M i/100ms
Calculating -------------------------------------
                simd     14.719M (± 0.5%) i/s   (67.94 ns/i) -     74.350M in   5.051379s

Comparison:
master:  2389369.8 i/s
  simd: 14718663.6 i/s - 6.16x  faster

== 1k few matches ==
ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +YJIT +PRISM [arm64-darwin25]
Warming up --------------------------------------
                simd   163.731k i/100ms
Calculating -------------------------------------
                simd      1.702M (± 0.6%) i/s  (587.67 ns/i) -      8.514M in   5.003388s

Comparison:
master:  1405436.9 i/s
  simd:  1701649.4 i/s - 1.21x  faster

== 1k many matches ==
ruby 4.0.6 (2026-07-14 revision 03b6d3f889) +YJIT +PRISM [arm64-darwin25]
Warming up --------------------------------------
                simd   153.148k i/100ms
Calculating -------------------------------------
                simd      1.590M (± 1.2%) i/s  (629.01 ns/i) -      7.964M in   5.009249s

Comparison:
master:  1225987.4 i/s
  simd:  1589798.4 i/s - 1.30x  faster
```

NB: I don't have an x86_64 machine to benchmark SSE2, which also mean I don't expect CI to pass on the first try...